### PR TITLE
add POM for login page

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,3 +11,5 @@ export { TestFixtureHandler } from './common-utils/network/test-fixture-handler.
 export { CommonUI } from './common-utils/common-UI/common-UI.js'
 
 export { MiscUtils } from './common-utils/misc-utils.js'
+
+export { LoginPage } from './page-object-model/login-page/login-page.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tianleh/tianleh-test-utility",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/page-object-model/login-page/login-page-elements.js
+++ b/page-object-model/login-page/login-page-elements.js
@@ -1,0 +1,5 @@
+export const LOGIN_PAGE_ELEMENTS = {
+    USER_NAME_INPUT: '[data-test-subj="user-name"]',
+    PASSWORD_INPUT: '[data-test-subj="password"]',
+    SUBMIT_BUTTON: '[data-test-subj="submit"]'
+}

--- a/page-object-model/login-page/login-page.js
+++ b/page-object-model/login-page/login-page.js
@@ -1,0 +1,19 @@
+import { LOGIN_PAGE_ELEMENTS } from './login-page-elements'
+
+export class LoginPage {
+    constructor(inputTestRunner) {
+        this.testRunner = inputTestRunner;
+    }
+
+    enterUserName(userName) {
+        this.testRunner.get(LOGIN_PAGE_ELEMENTS.USER_NAME_INPUT, { timeout: 60000 }).should('be.visible').type(userName)
+    }
+
+    enterPassword(password) {
+        this.testRunner.get(LOGIN_PAGE_ELEMENTS.PASSWORD_INPUT).should('be.visible').type(password)
+    }
+
+    submit() {
+        this.testRunner.get(LOGIN_PAGE_ELEMENTS.SUBMIT_BUTTON).should('be.visible').click()
+    }
+}


### PR DESCRIPTION
This will add the POM for login page. 

**Test**
See this success run for reference. The OS and OSD are using bundled artifact.

<img width="2553" alt="Screen Shot 2021-09-10 at 9 35 17 PM" src="https://user-images.githubusercontent.com/60111637/132936570-abf7bcdb-fcd5-4fe3-9eac-c57d7dd0a075.png">

More test will be done at https://github.com/tianleh/monterey-test
